### PR TITLE
fix: exclude identical rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.2
+
+Bug fixes:
+
+- Exclude identical rows from the report
+- Avoid `NA` entries for "Provnr" when material is missing
+
 ## 0.1.1
 
 Bug fixes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /tumor_evolution
 
 ENTRYPOINT ["Rscript", "tumor_evolution_report.R"]
 
-LABEL version="0.1.1"
+LABEL version="0.1.2"
 LABEL description="Visualisation of tumor evolution at Norrlands Universitetssjukhus"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are quite a few dependencies, both R and TeX, so using Docker is recommend
 Build the image:
 
 ```bash
-docker build --tag tumor-evolution:0.1.1 .
+docker build --tag tumor-evolution:0.1.2 .
 ```
 
 Generate the report.
@@ -41,5 +41,5 @@ docker run \
     --rm \
     -v /path/to/data.xlsx:/tumor_evolution/data/follow_up_data.xlsx:ro \
     -v /path/to/output:/tumor_evolution/reports \
-    tumor-evolution:0.1.1 <sheet>
+    tumor-evolution:0.1.2 <sheet>
 ```

--- a/report_template.qmd
+++ b/report_template.qmd
@@ -91,7 +91,7 @@ vaf_plot <- ggplot(d2, aes(Provtagningsdag, VAF, colour = name, fill = name)) +
 ```{r build_table}
 vaf_table <- d2 %>% ungroup() %>%
   select(Provtagningsdag, Provnr, Material, Symbol, HGVSc, HGVSp, mod_vaf, Sekvensdjup, Kommentar) %>%
-  mutate(id_material = str_c(Provnr, Material, sep = " "),
+  mutate(id_material = str_c(Provnr, str_replace_na(Material, ""), sep = " "),
          Kommentar = ifelse(is.na(Kommentar), "", Kommentar),
          mod_vaf = format_vaf(mod_vaf),
          HGVS = str_c(HGVSc, HGVSp, sep = ", ")) %>%

--- a/tumor_evolution.R
+++ b/tumor_evolution.R
@@ -78,12 +78,19 @@ d <- d %>%
          name = forcats::fct(name),
          Bedömning = str_trim(str_to_lower(Bedömning)))
 
-# Remove VUS, benign, and likely benign
+# Exctract VUS, benign, and likely benign variants.
 vus <- d %>%
     filter(Bedömning %in% c("vus", "benign", "likely benign")) %>%
     with(unique(name))
 
-variant_df <- d %>% filter(!name %in% vus)
+# Remove duplicate rows and VUS. This will remove all rows that are
+# completely identical across all columns, with the exception of "Remiss".
+# The first row in each group of identical rows is kept.
+variant_df <- d %>%
+    group_by(Provnr) %>%
+    distinct(across(-Remiss), .keep_all=TRUE) %>%
+    filter(!name %in% vus)
+
 annot_df <- d %>%
     filter(is.na(VAF), !is.na(Kommentar)) %>%
     select(Provtagningsdag, label = Kommentar)

--- a/tumor_evolution.R
+++ b/tumor_evolution.R
@@ -21,7 +21,7 @@ Options:
                     [default: /tumor_evolution/data/follow_up_data.xlsx]
 " -> doc
 
-args <- docopt::docopt(doc, version = "tumor-evolution 0.1.1")
+args <- docopt::docopt(doc, version = "tumor-evolution 0.1.2")
 
 write_log <- function(msg, type = "error") {
     writeLines(str_c(type, ": ", msg),


### PR DESCRIPTION
This PR makes it so that identical rows are excluded from the report. In fixing this I also noticed that the column "Provnr" could become `NA` if the material was missing. This has now been fixed.