### PR TITLE
fix: correctly identify annotation rows

### DIFF
--- a/tumor_evolution.R
+++ b/tumor_evolution.R
@@ -92,7 +92,7 @@ variant_df <- d %>%
     filter(!name %in% vus)
 
 annot_df <- d %>%
-    filter(is.na(VAF), !is.na(Kommentar)) %>%
+    filter(is.na(VAF), is.na(Symbol), !is.na(Kommentar)) %>%
     select(Provtagningsdag, label = Kommentar)
 
 # File name should be based on the most recent sample ID


### PR DESCRIPTION
Previously, annotaton rows were identified by checking for an existing comment and a missing VAF. However, it turns out there can be variants without a reported VAF. Now, in addition to these two checks, it also checks for a missing gene symbol.