### PR TITLE
fix: don't fill if values are missing

### DIFF
--- a/tumor_evolution.R
+++ b/tumor_evolution.R
@@ -69,8 +69,11 @@ if (length(missing_columns) > 0) {
 }
 
 d <- d %>%
-  fill(`Archer version`, Remiss, Provnr, Provtagningsdag, Material,
+  fill(Provtagningsdag) %>%
+  group_by(Provtagningsdag) %>%
+  fill(`Archer version`, Remiss, Provnr, Material,
        .direction = "down") %>%
+  ungroup() %>%
   mutate(HGVSp = str_trim(HGVSp),
          HGVSc = str_trim(HGVSc),
          Symbol = str_trim(Symbol),


### PR DESCRIPTION
This is a fix addressing issue #6. Now it is assumed that each group at least has a date associated with it. The dates are first filled, then the table is grouped according to date and the rest of the values are filled. Close #6.