### PR TITLE
feat: set minimal y-axis value to 50%

### DIFF
--- a/report_template.qmd
+++ b/report_template.qmd
@@ -69,7 +69,8 @@ vaf_plot <- ggplot(d2, aes(Provtagningsdag, VAF, colour = name, fill = name)) +
                    sec.axis = sec_axis(~ .,
                                        breaks = unique(annotation_df$Provtagningsdag),
                                        labels = annotation_df$label)) +
-  scale_y_continuous(labels = scales::label_percent()) +
+  scale_y_continuous(labels = scales::label_percent(),
+                     limits = c(0, max(0.5, max(d2$VAF)))) +
   labs(y = "VAF (%)") +
   theme_bw() +
   theme(


### PR DESCRIPTION
To avoid having small changes look bigger than they are, lock the y-axis to a frequency of at least 50%.