### PR TITLE
fix: better table page breaks

### DIFF
--- a/footer_config.tex
+++ b/footer_config.tex
@@ -10,6 +10,7 @@
 }
 
 \pagestyle{fancy}
+\renewcommand{\headrulewidth}{0pt}
 \fancyfoot[C]{{\thepage}({\pageref{LastPage})}}
 % x-release-please-start-version
 \fancyfoot[R]{version 0.5.2}

--- a/report_template.qmd
+++ b/report_template.qmd
@@ -156,5 +156,5 @@ print(kableExtra::kbl(vaf_table,
         kableExtra::column_spec(4, width = "4.5cm") %>%
         kableExtra::column_spec(7, width = "4cm") %>%
         kableExtra::collapse_rows(columns = c(1, 2), valign = "middle", latex_hline = "major") %>%
-        kableExtra::kable_classic_2(latex_options = c("repeat_header")))
+        kableExtra::kable_classic_2(latex_options = c("repeat_header", "striped"), stripe_color = "gray!9"))
 ```

--- a/report_template.qmd
+++ b/report_template.qmd
@@ -155,6 +155,6 @@ print(kableExtra::kbl(vaf_table,
         kableExtra::column_spec(2, width = "1.5cm") %>%
         kableExtra::column_spec(4, width = "4.5cm") %>%
         kableExtra::column_spec(7, width = "4cm") %>%
-        kableExtra::collapse_rows(columns = c(1, 2), valign = "middle") %>%
+        kableExtra::collapse_rows(columns = c(1, 2), valign = "middle", latex_hline = "major") %>%
         kableExtra::kable_classic_2(latex_options = c("repeat_header")))
 ```


### PR DESCRIPTION
This PR fixes an issue where the table did not break nicely across pages. Sometimes the columns that span multiple rows overlapped with the header, and it looked generally messy. Using only major hlines solved this issues since these are the ones that are used when deciding where the table can be split across pages. In addition, the rows are also made striped in order to increase readability now that all the other hlines are gone.