### PR TITLE
fix: increase the number of significant digits for VAF

### DIFF
--- a/report_template.qmd
+++ b/report_template.qmd
@@ -75,7 +75,7 @@ vaf_plot <- ggplot(d2, aes(Provtagningsdag, VAF, colour = name, fill = name)) +
   geom_area(alpha = 0.3) +
   geom_point(data = d2 %>% filter(!is.na(Bedömning), Bedömning != "ej påvisad"), size = 3) +
   ggrepel::geom_text_repel(
-    aes(label = round(100 * mod_vaf, digits = 1)),
+    aes(label = round(100 * mod_vaf, digits = 2)),
     hjust = 2, vjust = 0.5, fontface = "bold",
     colour = "black", box.padding = 0.25) +
   scale_colour_discrete(name = "Variant") +
@@ -146,7 +146,7 @@ vaf_plot / x_axis_labels + plot_layout(heights = c(0.92, 0.08))
 ```{r output_table, results = "asis"}
 print(kableExtra::kbl(vaf_table,
                       align = "llllrrl",
-                      digits = 1,
+                      digits = 2,
                       format = "latex",
                       booktabs = TRUE,
                       longtable = TRUE,


### PR DESCRIPTION
The issue was that whenever a VAF under 0.001 was reported, it would be rounded to 0. Increasing the number of significant digits addresses this issue, but it also leads to somewhat of a misrepresentation of the precision of the analysis. For now though, it is more important that these variants of low frequency are represented accurately. Whether or not we want to do a conditional formatting of VAF values, similar to what we had in [v0.1.3](https://github.com/gmc-norr/tumor-evolution/tree/v0.1.3), will have to be a question we address in the future.