### PR TITLE
fix: show points for all samples

### DIFF
--- a/report_template.qmd
+++ b/report_template.qmd
@@ -70,7 +70,7 @@ vaf_plot <- ggplot(d2, aes(Provtagningsdag, VAF, colour = name, fill = name)) +
   ) +
   geom_line(linewidth = 1) +
   geom_area(alpha = 0.3) +
-  geom_point(data = d2 %>% filter(!is.na(Bedömning), Bedömning != "ej påvisad"), size = 3) +
+  geom_point(data = d2, size = 3) +
   ggrepel::geom_text_repel(
     data = d2 %>% filter(Provtagningsdag %in% range(Provtagningsdag)),
     aes(label = round(100 * mod_vaf, digits = 2)),


### PR DESCRIPTION
Previously, if the VAF for a sample was below the limit of detection a point would not be drawn for this sample in the plot. This was not a problem since the x-axis labels made it apparent that there was sampling done at this time. With the cleanup of the labels in the previous release this is no longer the case.

This PR makes it so that points are plotted for all samples, regardless of whether they are below the limit of detection or not.