### PR TITLE
fix: use HGVSc in plots if HGVSp is unknown

### DIFF
--- a/tumor_evolution.R
+++ b/tumor_evolution.R
@@ -97,10 +97,13 @@ d <- d %>%
   fill(`Archer version`, Remiss, Provnr, Material,
        .direction = "down") %>%
   ungroup() %>%
-  mutate(HGVSp = str_trim(HGVSp),
-         HGVSc = str_trim(HGVSc),
+  mutate(HGVSp = coalesce(str_trim(HGVSp), "p.?"),
+         HGVSc = coalesce(str_trim(HGVSc), "c.?"),
          Symbol = str_trim(Symbol),
-         name = str_c(Symbol, case_when(str_detect(HGVSp, "^p\\.\\?$") ~ HGVSc, TRUE ~ HGVSp), sep = " "),
+         name = str_c(Symbol,
+                      case_when(str_detect(HGVSp, "^p\\.\\?$") ~ HGVSc,
+                                TRUE ~ HGVSp),
+                      sep = " "),
          name = forcats::fct(name),
          Bedömning = str_trim(str_to_lower(Bedömning)))
 

--- a/tumor_evolution.R
+++ b/tumor_evolution.R
@@ -100,7 +100,7 @@ d <- d %>%
   mutate(HGVSp = str_trim(HGVSp),
          HGVSc = str_trim(HGVSc),
          Symbol = str_trim(Symbol),
-         name = str_c(Symbol, HGVSp, sep = " "),
+         name = str_c(Symbol, case_when(str_detect(HGVSp, "^p\\.\\?$") ~ HGVSc, TRUE ~ HGVSp), sep = " "),
          name = forcats::fct(name),
          Bedömning = str_trim(str_to_lower(Bedömning)))
 


### PR DESCRIPTION
For the panel titles in the plot the HGVSc annotation has been used. However, in the case of splice variants, the protein change is unknown and represented as "p.?". Since this is not very informative, we instead opt to show the DNA modification in cases where HGVSp matches the string "p.?". The recommendation from HGVS is to use this nomenclature for splice variants, and we just have to trust that the annotations follow this convention.

If either HGVSc or HGVSp is missing, they are set to `c.?` and `p.?`, respectively.